### PR TITLE
Make FreeRTOS work in debug mode

### DIFF
--- a/src/rtos/opencm3.c
+++ b/src/rtos/opencm3.c
@@ -9,6 +9,9 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/cm3/nvic.h>
 
+#pragma GCC push_options
+#pragma GCC optimize("-Os")
+
 extern void vPortSVCHandler( void ) __attribute__ (( naked ));
 extern void xPortPendSVHandler( void ) __attribute__ (( naked ));
 extern void xPortSysTickHandler( void );
@@ -24,5 +27,5 @@ void pend_sv_handler(void) {
 void sys_tick_handler(void) {
 	xPortSysTickHandler();
 } 
-
+#pragma GCC pop_options
 /* end opncm3.c */


### PR DESCRIPTION
Per https://stackoverflow.com/a/31375290/5296568 and https://community.platformio.org/t/built-type-debug-unexpected-behavior/21465/9?u=maxgerhardt. 

Without optimization of these functions, an additional call is created which really messes with the scheduler that expects the link-register to point somwhere else.